### PR TITLE
fix a couple small bugs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ be reasonable to reach Rebol3 in performance.
 There is also a beginning of a Spry VM module (src/modules/spryui.nim) for making GUI stuff using the excellent [libui](http://github.com/andlabs/libui) project. A small trivial little IDE written in Spry itself exists and you can build it on Linux or OSX.
 
 * **OSX:** Just run `./makeideosx.sh` in `src` and if you are lucky that produces a binary file called `ideosx`. Try running it with `./ideosx`.
-* **Linux:** Just run `./makeideo.sh` in `src` and if you are lucky that produces a binary file called `ide`. Try running it with `./ide`.
+* **Linux:** Just run `./makeide.sh` in `src` and if you are lucky that produces a binary file called `ide`. Try running it with `./ide`.
 
 ## History
 Spry started out as a Rebol inspired interpreter - since I felt the homoiconicity

--- a/src/makeide.sh
+++ b/src/makeide.sh
@@ -1,3 +1,5 @@
+# Stop the script if a command fails 
+set -e 
 # Make executable from ide.sy
 rm -f ide.nim
 cat << EOF > ./ide.nim


### PR DESCRIPTION
- Fix a rather confusing typo in README	

- makeide.sh should fail on lines with nonzero exit status -- this way if the `nim` or `strip` commands do not exist, for example, the script is stopped, instead of probably failing in a weird way